### PR TITLE
Fix: allow dismissing photo picker on macOS when Photos library is empty

### DIFF
--- a/KeePassium/util/photo-picker/GalleryPhotoPicker.swift
+++ b/KeePassium/util/photo-picker/GalleryPhotoPicker.swift
@@ -24,6 +24,9 @@ final class GalleryPhotoPicker: PhotoPicker {
 
         picker.delegate = self
         picker.presentationController?.delegate = self
+        #if targetEnvironment(macCatalyst)
+        picker.isModalInPresentation = false
+        #endif
     }
 
     override internal func _pickImageInternal() {
@@ -44,7 +47,7 @@ final class GalleryPhotoPicker: PhotoPicker {
     }
 }
 
-extension GalleryPhotoPicker: UIAdaptivePresentationControllerDelegate {
+extension GalleryPhotoPicker: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         guard let result = results.first,
               result.itemProvider.canLoadObject(ofClass: UIImage.self)
@@ -98,7 +101,7 @@ extension GalleryPhotoPicker: UIAdaptivePresentationControllerDelegate {
     }
 }
 
-extension GalleryPhotoPicker: PHPickerViewControllerDelegate {
+extension GalleryPhotoPicker: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         _completion?(.success(nil))
     }


### PR DESCRIPTION
Fixes #507

**Problem:** On Mac Catalyst, when the user's Photos library is empty, the `PHPickerViewController` has no cancel button and `isModalInPresentation` defaults to `true`, preventing dismissal via Escape or clicking outside the sheet. The user is trapped and must force-quit.

**Fix:** Set `isModalInPresentation = false` on Mac Catalyst so the picker sheet can always be dismissed interactively (Escape key or clicking outside).

Also corrects swapped extension conformance labels — `PHPickerViewControllerDelegate` and `UIAdaptivePresentationControllerDelegate` were on the wrong extensions (no behavioral change, just correctness).