### PR TITLE
Fix: add Cancel button to photo picker on macOS when Photos library is empty

### DIFF
--- a/KeePassium/util/photo-picker/GalleryPhotoPicker.swift
+++ b/KeePassium/util/photo-picker/GalleryPhotoPicker.swift
@@ -27,8 +27,29 @@ final class GalleryPhotoPicker: PhotoPicker {
     }
 
     override internal func _pickImageInternal() {
-        _presenter?.present(picker, animated: true, completion: nil)
+        _presenter?.present(picker, animated: true) { [weak self] in
+            #if targetEnvironment(macCatalyst)
+            // On macOS, PHPickerViewController shows no close button when the Photos library is
+            // empty, leaving the user with no way to dismiss it (issue #507).
+            // Inject a Cancel button into the navigation bar as a reliable escape hatch.
+            guard let self else { return }
+            let cancelButton = UIBarButtonItem(
+                barButtonSystemItem: .cancel,
+                target: self,
+                action: #selector(self.cancelPicker)
+            )
+            self.picker.navigationItem.leftBarButtonItem = cancelButton
+            #endif
+        }
     }
+
+    #if targetEnvironment(macCatalyst)
+    @objc private func cancelPicker() {
+        _presenter?.dismiss(animated: true) { [weak self] in
+            self?._completion?(.success(nil))
+        }
+    }
+    #endif
 
     override class func isAllowed() -> Bool {
         #if INTUNE


### PR DESCRIPTION
## Problem

Fixes #507.

When the macOS Photos library is empty, `PHPickerViewController` renders with no close/cancel button and ignores `Esc`/`Cmd+Q`, leaving the user unable to dismiss the picker without force-quitting KeePassium.

## Root cause

On macOS Catalyst, `PHPickerViewController` normally shows a Cancel button only when there is content to browse. With an empty library it shows a blank sheet with no interactive controls, and the system does not forward keyboard shortcuts to dismiss it.

## Fix

After presenting the picker, inject a `UIBarButtonItem(.cancel)` into `picker.navigationItem.leftBarButtonItem` inside a `#if targetEnvironment(macCatalyst)` guard. Tapping it dismisses the picker and calls the completion handler with `nil`, matching the existing behaviour for a cancelled pick on all other paths.

The change is compile-time gated so it has zero impact on iOS builds.